### PR TITLE
refactor: centralize test configuration, unify CI, and enforce strict…

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -1,0 +1,16 @@
+name: Framework CI
+
+on:
+  workflow_call:
+
+jobs:
+  unified-ci:
+    name: Framework Unified Quality Gate
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Run Unified CI Script
+        run: chmod +x ./caffeine-build/scripts/*.sh && ./caffeine-build/scripts/ci.sh

--- a/README.md
+++ b/README.md
@@ -30,56 +30,48 @@ This repository is the centralized build infrastructure for the **Caffeine Frame
 
 By decoupling the build system from the code repositories, `caffeine-build` ensures:
 1.  **Single Source of Truth:** CMake toolchains, hardware presets, and common macros are defined once.
-2.  **IDE Compatibility:** Because it is cloned as a submodule before CMake runs, `CMakePresets.json` in consuming repositories can reliably inherit from `caffeine-build/cmake/presets/base-arm.json` without parsing errors in IDEs like CLion or VSCode.
-3.  **Unified Build Scripts:** A single `scripts/build.sh` script orchestrates Dockerized or native cross-compilation identically across all projects.
+2.  **IDE Compatibility:** Because it is cloned as a submodule before CMake runs, `CMakePresets.json` in consuming repositories can reliably inherit from `caffeine-build/cmake/presets/base.json`.
+3.  **Unified Build Orchestration:** A standardized set of scripts (`build.sh`, `ci.sh`) ensures identical build and quality gate behavior locally and in CI.
 
 ## Directory Structure
 
 *   `cmake/toolchains/`: Cross-compiler definitions (e.g., `arm-gcc.cmake`, `riscv-gcc.cmake`).
-*   `cmake/presets/`: Modular `CMakePresets.json` files for vendor targets (e.g., STM32F407, GD32V).
-*   `cmake/CaffeineMacros.cmake`: Helper functions (e.g., `cfn_add_firmware()`) to automate `.hex`/`.bin` generation.
-*   `scripts/build.sh`: Unified build orchestrator.
-*   `config/coding/`: Global coding standards (`.clang-format` and `.clang-tidy`).
+*   `cmake/presets/`: Centralized `base.json` containing shared configuration and test presets (`unit-tests-gtest`).
+*   `cmake/CaffeineMacros.cmake`: Reusable functions (e.g., `cfn_add_firmware()`, `cfn_get_clang_tidy_extra_args()`).
+*   `scripts/build.sh`: Main build orchestrator supporting incremental builds and custom binary dirs.
+*   `scripts/ci.sh`: Unified CI script that validates all presets in a project.
+*   `config/coding/`: Global coding standards (`.clang-format`, `.clang-tidy`, `cppcheck-suppressions.txt`).
+
+## Standardized Quality Gates
+
+The repository provides two primary scripts for local and CI development:
+- **`scripts/build.sh`**: Orchestrates builds for specific presets and targets.
+- **`scripts/ci.sh`**: The unified quality gate. It discovers all non-hidden presets and runs:
+  1. **Format Check:** Dry-run validation of coding style.
+  2. **Static Analysis:** Deep analysis via `clang-tidy` and `cppcheck` (Fail-on-warning).
+  3. **Compilation:** Full build of all targets.
+  4. **Unit Tests:** Automated execution via `ctest` for test-enabled presets.
 
 ## Usage in Applications
 
-To use this build system in a new Caffeine application:
-
-1.  Add this repository as a submodule:
-    ```bash
-    git submodule add https://github.com/while-one/caffeine-build.git caffeine-build
-    ```
-2.  Create a local `CMakePresets.json` that inherits from a build preset:
+1.  Add this repository as a submodule: `git submodule add https://github.com/while-one/caffeine-build.git caffeine-build`
+2.  Inherit from `base.json` in your local `CMakePresets.json`:
     ```json
     {
-      "version": 4,
-      "include": ["caffeine-build/cmake/presets/base-arm.json"],
+      "include": ["caffeine-build/cmake/presets/base.json"],
       "configurePresets": [
         {
-          "name": "app-stm32f407",
+          "name": "my-target",
           "inherits": "base-arm",
           "cacheVariables": {
             "CFN_HAL_PORT_VENDOR": "stm32",
             "CFN_HAL_PORT_FAMILY": "stm32f4",
-            "CAFFEINE_MCU_MACRO": "STM32F407xx",
-            "CAFFEINE_BOARD_LINKER": "STM32F407VGTX_FLASH.ld"
+            "CFN_HAL_PORT_TARGET": "stm32f417vgtx"
           }
         }
       ]
     }
     ```
-3.  Load the macros in your `CMakeLists.txt`:
-    ```cmake
-    include(caffeine-build/cmake/CaffeineMacros.cmake)
-    # ... your targets ...
-    cfn_add_firmware(my_target)
-    ```
-
-## Shared Ecosystem Standards
-
-All repositories using `caffeine-build` inherit the framework's strict coding standards via the `config/` directory:
-*   **Formatting:** Enforces a 120-column limit, 4-space indentation, and Allman-style braces.
-*   **Static Analysis:** Enforces strict C11 compliance, memory safety rules (no dynamic allocation).
 
 ---
 

--- a/cmake/CaffeineMacros.cmake
+++ b/cmake/CaffeineMacros.cmake
@@ -23,6 +23,18 @@ if(CAFFEINE_WARNINGS_AS_ERRORS)
     list(APPEND CAFFEINE_COMPILE_OPTIONS -Werror)
 endif()
 
+# Global cppcheck flags for consistent static analysis across the framework.
+# We fail the build on any warning (--error-exitcode=1) and use a centralized
+# suppressions list located in caffeine-build.
+set(CFN_CPPCHECK_FLAGS
+    --enable=all
+    --error-exitcode=1
+    --inline-suppr
+    --std=c11
+    --suppressions-list=${PROJECT_SOURCE_DIR}/caffeine-build/config/coding/cppcheck-suppressions.txt
+    --suppress=unmatchedSuppression
+)
+
 # ==============================================================================
 # Helper Macros
 # ==============================================================================

--- a/cmake/presets/base.json
+++ b/cmake/presets/base.json
@@ -11,6 +11,17 @@
       }
     },
     {
+      "name": "unit-tests-gtest",
+      "displayName": "Caffeine Unit Tests (Native Host)",
+      "description": "Standardized unit test configuration using the host compiler",
+      "inherits": "base-common",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/unit-tests-gtest",
+      "cacheVariables": {
+        "CFN_BUILD_TESTS": "ON"
+      }
+    },
+    {
       "name": "base-hardware-defaults",
       "hidden": true,
       "cacheVariables": {
@@ -56,6 +67,15 @@
       "toolchainFile": "${sourceDir}/caffeine-build/cmake/toolchains/riscv-gcc.cmake",
       "cacheVariables": {
         "CAFFEINE_BUILD_STAGE": "build-riscv"
+      }
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "unit-tests-gtest",
+      "configurePreset": "unit-tests-gtest",
+      "output": {
+        "outputOnFailure": true
       }
     }
   ]

--- a/config/coding/.clang-tidy
+++ b/config/coding/.clang-tidy
@@ -14,7 +14,7 @@ Checks: >
   -bugprone-easily-swappable-parameters
 
 # Warnings as errors ensures you don't ignore these in CI
-WarningsAsErrors: 'readability-identifier-naming,bugprone-narrowing-conversions'
+WarningsAsErrors: '*'
 
 CheckOptions:
   # --- BARR-C Rule 2.1: Naming Conventions ---

--- a/config/coding/cppcheck-suppressions.txt
+++ b/config/coding/cppcheck-suppressions.txt
@@ -1,0 +1,3 @@
+unusedFunction
+missingIncludeSystem
+*:*/_deps/*

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -74,12 +74,20 @@ docker pull "$IMAGE_NAME" || {
 # We use an array to maintain proper quoting when passing to bash -c
 if [ -f "CMakePresets.json" ]; then
     # Modern Preset-based Workflow
-    CMD="cmake --preset $PRESET ${EXTRA_ARGS[*]} && \
-         cmake --build $BINARY_DIR --target $TARGET"
+    if [ "$TARGET" == "ctest" ]; then
+        CMD="ctest --preset $PRESET --output-on-failure"
+    else
+        CMD="cmake --preset $PRESET ${EXTRA_ARGS[*]} && \
+             cmake --build $BINARY_DIR --target $TARGET"
+    fi
 else
     # Standard Native Workflow
-    CMD="cmake -B build -DFETCHCONTENT_FULLY_DISCONNECTED=OFF ${EXTRA_ARGS[*]} && \
-         cmake --build build --target $TARGET"
+    if [ "$TARGET" == "ctest" ]; then
+        CMD="cd build && ctest --output-on-failure"
+    else
+        CMD="cmake -B build -DFETCHCONTENT_FULLY_DISCONNECTED=OFF ${EXTRA_ARGS[*]} && \
+             cmake --build build --target $TARGET"
+    fi
 fi
 
 # --- 5. Execution (Containerized) ---

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+set -e
+
+# ==============================================================================
+# Caffeine Framework Unified CI Orchestrator
+# ==============================================================================
+
+PROJECT_ROOT=$(pwd)
+BUILD_SCRIPT="${PROJECT_ROOT}/caffeine-build/scripts/build.sh"
+
+if [ ! -f "CMakePresets.json" ]; then
+    echo "Error: CMakePresets.json not found in $(pwd)"
+    exit 1
+fi
+
+# Get project name from CMakeLists.txt
+PROJECT_NAME=$(python3 -c "
+import re
+with open('CMakeLists.txt') as f:
+    content = f.read()
+    match = re.search(r'project\s*\(\s*([a-zA-Z0-9_-]+)', content, re.MULTILINE)
+    if match:
+        print(match.group(1))
+")
+
+if [ -z "$PROJECT_NAME" ]; then
+    echo "Error: Could not identify project name in CMakeLists.txt"
+    exit 1
+fi
+
+# Use cmake to list all available presets (handles inheritance and includes)
+# The output starts with two spaces then the preset name in double quotes
+ALL_PRESETS=$(cmake --list-presets | grep -E "^  \"" | cut -d'"' -f2 | grep -v "^base-")
+
+echo "--------------------------------------------------------------------------------"
+echo " Starting Unified CI for project: $PROJECT_NAME"
+echo "--------------------------------------------------------------------------------"
+
+if [ -z "$ALL_PRESETS" ]; then
+    echo "Warning: No presets found to validate."
+fi
+
+for PRESET in $ALL_PRESETS; do
+    # We query metadata inside the container via build.sh if needed, 
+    # but for now we query natively to see if we should run tests.
+    BUILD_TESTS=$(cmake --preset "$PRESET" -N 2>/dev/null | grep "CFN_BUILD_TESTS" | cut -d'=' -f2 | tr -d '"' | xargs || echo "OFF")
+    
+    echo ""
+    echo ">>> Validating Preset: $PRESET (Tests: ${BUILD_TESTS:-OFF})"
+    echo "--------------------------------------------------------------------------------"
+
+    # 1. Format Check (Dry-run)
+    echo "[1/4] Checking Formatting..."
+    $BUILD_SCRIPT --clean "$PRESET" "${PROJECT_NAME}-format" -DFORMAT_DRY_RUN=ON
+
+    # 2. Static Analysis
+    echo "[2/4] Running Static Analysis..."
+    $BUILD_SCRIPT "$PRESET" "${PROJECT_NAME}-analyze"
+
+    # 3. Build All
+    echo "[3/4] Building All Targets..."
+    $BUILD_SCRIPT "$PRESET" all
+
+    # 4. Run Tests (if enabled)
+    if [ "$BUILD_TESTS" == "ON" ]; then
+        echo "[4/4] Running Unit Tests..."
+        $BUILD_SCRIPT "$PRESET" ctest
+    else
+        echo "[4/4] Skipping Unit Tests."
+    fi
+done
+
+echo ""
+echo "--------------------------------------------------------------------------------"
+echo " Unified CI Completed Successfully!"
+echo "--------------------------------------------------------------------------------"


### PR DESCRIPTION
… analysis

This commit finalizes the framework refactoring by centralizing testing logic and unifying the continuous integration quality gate across all subprojects.

Key Changes:
1. Centralized Test Presets:
   - Moved 'unit-tests-gtest' configure and test presets to caffeine-build/base.json.
   - Removed redundant test preset redefinitions from all local repository files.

2. Unified CI Orchestration:
   - Created caffeine-build/scripts/ci.sh to dynamically discover and validate all presets in any framework repository.
   - Added a reusable GitHub Actions workflow in caffeine-build/.github/workflows.
   - Standardized local developer quality gate to a single './ci.sh' command.
3. Strict Static Analysis:
   - Enforced a framework-wide Zero-Warning Policy.
   - Configured .clang-tidy (WarningsAsErrors: '*') and cppcheck (--error-exitcode=1).
   - Centralized cppcheck flags and common suppressions in caffeine-build.
4. Documentation Synchronization:
   - Synchronized all GEMINI.md, README.md, and SKILL.md files to reflect the refactored build workflows, encapsulated hardware targets, and strict engineering standards.
   - Ensured framework headers and branding are consistent across all subprojects.

## Description
<!-- Provide a brief summary of the changes and the reasoning behind them. -->

## Type of Change
<!-- Please check the options that are relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist
- [ ] My code follows the project style (run `make format` locally)
- [ ] I have run static analysis (`make analyze`) and fixed any warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Version Bump
<!-- Select one. This will automate the SemVer update in CMakeLists.txt upon merge. -->
- [ ] major
- [ ] minor
- [x] patch
